### PR TITLE
Drop support for Laravel 10 & 11, add Laravel 13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [12.*, 13.*]
         os: [ubuntu-latest]
         coverage: [none]
         include:
           - php: 8.5
-            laravel: 12.*
+            laravel: 13.*
             os: ubuntu-latest
             coverage: xdebug
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Laravel package for validating in-app purchase receipts, managing subscription
 [![Latest Stable Version](https://img.shields.io/packagist/v/aporat/laravel-appstore-purchases.svg?style=flat-square&logo=composer)](https://packagist.org/packages/aporat/laravel-appstore-purchases)
 [![Downloads](https://img.shields.io/packagist/dt/aporat/laravel-appstore-purchases.svg?style=flat-square&logo=composer)](https://packagist.org/packages/aporat/laravel-appstore-purchases)
 [![codecov](https://codecov.io/github/aporat/laravel-appstore-purchases/graph/badge.svg?token=D44CU2TDU8)](https://codecov.io/github/aporat/laravel-appstore-purchases)
-[![Laravel Version](https://img.shields.io/badge/Laravel-12.x-orange.svg?style=flat-square)](https://laravel.com/docs/12.x)
+[![Laravel Version](https://img.shields.io/badge/Laravel-13.x-orange.svg?style=flat-square)](https://laravel.com/docs/13.x)
 ![GitHub Actions](https://img.shields.io/github/actions/workflow/status/aporat/laravel-appstore-purchases/ci.yml?style=flat-square)
 [![License](https://img.shields.io/packagist/l/aporat/laravel-appstore-purchases.svg?style=flat-square)](https://github.com/aporat/laravel-appstore-purchases/blob/master/LICENSE)
 

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
     "php": "^8.4",
     "ext-json": "*",
     "ext-openssl": "*",
-    "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+    "illuminate/support": "^12.0 || ^13.0",
     "aporat/store-receipt-validator": "dev-main"
   },
   "require-dev": {
-    "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
+    "orchestra/testbench": "^10.0 || ^11.0",
     "laravel/pint": "^1.21",
     "phpstan/phpstan": "^2.0",
     "phpunit/phpunit": "^12.0",


### PR DESCRIPTION
This PR updates the package to support Laravel 13 while dropping support for Laravel 10 and 11.

## Summary
The package now targets Laravel 12 and 13, aligning with the latest Laravel versions and their corresponding PHP 8.4+ requirements.

## Key Changes
- Updated CI/CD matrix to test against Laravel 12.* and 13.* (removed 10.* and 11.*)
- Updated `illuminate/support` dependency constraint from `^10.0 || ^11.0 || ^12.0` to `^12.0 || ^13.0`
- Updated `orchestra/testbench` dependency constraint from `^8.0 || ^9.0 || ^10.0` to `^10.0 || ^11.0`
- Updated coverage testing to run against Laravel 13.* with PHP 8.5
- Updated README badge to reflect Laravel 13.x as the primary supported version

## Notes
- PHP 8.4 remains the minimum supported version
- All changes maintain consistency across CI configuration, dependencies, and documentation

https://claude.ai/code/session_01VbtvDJVg61JBYQWNoYVotk